### PR TITLE
Set body background-attachment to scroll for responsive design

### DIFF
--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -1,5 +1,9 @@
 /* =================== RESPONSIVE =================== */
 @media (max-width: 768px) {
+  body{
+    background-attachment: scroll !important;
+  }
+
   .grid-container {
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     gap: 0.75rem;


### PR DESCRIPTION
Ensure the body background-attachment property is set to scroll for better responsiveness on smaller screens.