### PR TITLE
Update fullsizePath to use mounted image directory

### DIFF
--- a/src/content/photos/1413492243330764840-Magical.md
+++ b/src/content/photos/1413492243330764840-Magical.md
@@ -3,7 +3,7 @@ title: "Magical"
 slug: "magical"
 author: ".inventory"
 date: "2025-09-05T13:53:36"
-fullsizePath: "/images/original/1413492243330764840-Magical.png"
+fullsizePath: "/images/original-ext/1413492243330764840-Magical.png"
 thumbPath: "/images/thumbs/1413492243330764840-Magical-400.webp"
 width: 2560
 height: 1440


### PR DESCRIPTION
Change the `fullsizePath` in the photo metadata to point to the new mounted image directory.