### PR TITLE
fix(ci): Build-Skripte von sharp und esbuild wieder erlauben

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+# pnpm >=10 fuehrt Build-Skripte von Abhaengigkeiten nicht mehr ungefragt aus und
+# bricht sonst mit ERR_PNPM_IGNORED_BUILDS ab. sharp braucht seinen Build fuer
+# gen:thumbs, esbuild fuer den Astro-Build.
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Problem

Der Job `build-and-push-dockerfile-image` scheitert seit geraumer Zeit im Step **📦 Install project dependencies**:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.25.12, esbuild@0.27.7, sharp@0.34.5
Process completed with exit code 1
```

`deploy.yml` installiert mit `npm install -g pnpm` immer die neueste pnpm-Version. Seit pnpm 10 werden Build-Skripte von Abhängigkeiten nicht mehr ungefragt ausgeführt, und `pnpm install --frozen-lockfile` bricht deshalb ab.

`sharp` braucht seinen Build für `gen:thumbs`, `esbuild` für den Astro-Build.

## Lösung

Neue `pnpm-workspace.yaml`, die genau diesen beiden Paketen ihre Build-Skripte erlaubt — und nur diesen.

Der naheliegende `pnpm.onlyBuiltDependencies`-Block in `package.json` funktioniert **nicht** mehr; aktuelle pnpm-Versionen ignorieren ihn und weisen darauf hin:

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm.
```

## Verifikation

Lokal gegen die im CI verwendete Version (pnpm 11.11.0) nachgestellt:

- vorher: `pnpm install --frozen-lockfile` → Exit 1, `ERR_PNPM_IGNORED_BUILDS`
- nachher: Exit 0
- `sharp` lädt libvips 8.17.3 und erzeugt ein WebP-Thumbnail

## Anmerkung

`npm install -g pnpm` zieht weiterhin eine ungepinnte Version. Ein `packageManager`-Feld plus gepinnte Installation im Workflow würde verhindern, dass der nächste pnpm-Major den Build erneut umwirft. Bewusst nicht Teil dieses PRs, um den Diff klein zu halten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BC3SD89MGmNsWwVKBSra3T