### PR TITLE
fix(ci): pnpm-Version pinnen und Build-Image auf Node 22 heben

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
       # 📦 Install project dependencies
       - name: 📦 Install project dependencies
         run: |
-          npm install -g pnpm
+          npm install -g pnpm@11.11.0
           pnpm install --frozen-lockfile
 
       # 📥 Download files if not cached

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base image for all subsequent stages, using a minimal Node.js environment
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 # Optional build arguments for remote downloads (handled in CI workflow)
 ARG EXT_DL_URL_MARKDOWN

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "voidtales-gallery",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@11.11.0",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",


### PR DESCRIPTION
Folgefix zu #24. Der Install-Step im Runner läuft seitdem, der **Docker-Build** scheitert aber weiterhin:

```
#14 1.171   code: 'ERR_UNKNOWN_BUILTIN_MODULE'
#14 1.171 Node.js v20.20.2
#14 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" exit code: 1
Dockerfile:33
```

## Ursache

Der `Dockerfile` ruft `corepack enable`, ohne dass `package.json` ein `packageManager`-Feld besitzt. corepack zieht deshalb die neueste pnpm-Version — aktuell **11.11.0**. Die verlangt laut ihren `engines` `node >=22.13`, das Build-Image ist aber `node:20-alpine`.

Es ist dieselbe Krankheit wie in #24: eine ungepinnte pnpm-Version, die sich unter dem Projekt wegbewegt. In #24 hatte ich das Pinning noch bewusst weggelassen, um den Diff klein zu halten. Das war die falsche Entscheidung.

## Änderung

| Datei | Was |
|---|---|
| `package.json` | `"packageManager": "pnpm@11.11.0"` — steuert corepack im Image |
| `Dockerfile` | `node:20-alpine` → `node:22-alpine`, erfüllt pnpms engine-Anforderung |
| `deploy.yml` | `npm install -g pnpm@11.11.0` statt floating `latest` |

Der finale Container bleibt `nginx:alpine`. Node wird ausschließlich zum Bauen verwendet, Stage 3 (`dokploy`) ist laut Kommentar im Dockerfile ohnehin ungenutzt.

## Verifikation

- `pnpm@11.11.0 install --frozen-lockfile` lokal → Exit 0
- `sharp` lädt libvips 8.17.3 und erzeugt ein WebP-Thumbnail
- `pnpm-lock.yaml` enthält die musl-Binaries für sharp, der Alpine-Build bleibt tragfähig

Docker war lokal nicht verfügbar, der Image-Build konnte nicht vorab nachgestellt werden — der CI-Lauf auf diesem Branch ist der eigentliche Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BC3SD89MGmNsWwVKBSra3T